### PR TITLE
Changes to make the helm install work

### DIFF
--- a/charts/pdp-engine/templates/pdp-deployment.yml
+++ b/charts/pdp-engine/templates/pdp-deployment.yml
@@ -40,7 +40,7 @@ spec:
             name: um-pdp-engine-config
         volumeMounts:
         - mountPath: /data/db/
-          sub_path: pep-engine/db/policy
+          subPath: pep-engine/db/policy
           name: eoepca-pdp-pv-host
       hostAliases:
       - ip: {{ .Values.global.nginxIp }}

--- a/charts/pdp-engine/templates/pvc.yaml
+++ b/charts/pdp-engine/templates/pvc.yaml
@@ -11,8 +11,6 @@ metadata:
 spec:
   accessModes:
     - {{ .Values.persistence.accessModes }}
-  capacity:
-    storage: {{ .Values.persistence.dbStorageSize }}
   resources:
     requests:
       storage: {{ .Values.persistence.dbStorageSize }}


### PR DESCRIPTION
When I installed on my enviroment I had the following errors:
`Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(PersistentVolumeClaim.spec): unknown field "capacity" in io.k8s.api.core.v1.PersistentVolumeClaimSpec`

I deleted the 'capacity' value from 'spec' in pvc.yaml
then i had the following error:
` Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[1].volumeMounts[0]): unknown field "sub_path" in io.k8s.api.core.v1.VolumeMount` 
I relace 'sub_path' for subPath in pdp-deployement

Now it appears to be working